### PR TITLE
Chore/#17 레이아웃, 및 기타 환경 설정

### DIFF
--- a/hustle_web/src/constants/styles/GlobalStyle.tsx
+++ b/hustle_web/src/constants/styles/GlobalStyle.tsx
@@ -1,15 +1,23 @@
 import { createGlobalStyle } from 'styled-components';
 
-const GlobalStyle = createGlobalStyle`
+export const supportScreenSize = 1080;
 
-* {
-    font-family: 'Pretendard', 'Malgun Gothic', sans-serif;
+export const GlobalStyle = createGlobalStyle`
+  html {
+    font-size: 62.5%; 
+
+    @media all and (max-width: ${supportScreenSize}px) {
+      font-size: 31.25%;
+    }
   }
-#root{
-  width:100%;
-  height:100%;
-}
+
+  body {
+    background: white;
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, sans-serif, Roboto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 `;
-
-
-export default GlobalStyle;

--- a/hustle_web/src/index.tsx
+++ b/hustle_web/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import GlobalStyle from "./constants/styles/GlobalStyle";
+import {GlobalStyle} from "./constants/styles/GlobalStyle";
 import {RecoilRoot} from "recoil";
 
 const root = ReactDOM.createRoot(

--- a/hustle_web/src/layout/DefaultLayout.tsx
+++ b/hustle_web/src/layout/DefaultLayout.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styled from "styled-components";
+import {supportScreenSize} from "../constants/styles/GlobalStyle";
+
+const DefaultLayout = () => {
+    //페이지가 로딩할 때 액션을 넣으면 될듯
+
+    return (
+        <Root>
+            {/*<Header />*/}
+            {/*<Content />*/}
+            {/*<Footer />*/}
+        </Root>
+    );
+};
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1080px;
+  height: 100vh;
+  background-color: mediumvioletred;
+
+  @media all and (max-width: ${supportScreenSize}px) {
+    width: 100vw;
+  }
+`;
+
+export default DefaultLayout;


### PR DESCRIPTION
## 📌 관련 이슈
Chore/#17 레이아웃, 및 기타 환경 설정

## ✨ PR Checklist
- [ ] 미디어 쿼리 이용해서 가로폭 1080을 기준치로 설정

## 📸 핵심 변동사항(사진은 선택)
GlobalStyle 부분 확인해주세요(/components/styles

## 📚 리뷰어 유의사항
글로벌 스타일 선언 추가 필요
가로폭 1080을 기준으로 더 작게 되면 글꼴이 비율에 맞게 축소됨(1080대신 1440 기준으로?? max-weighr or min-weight??)
현재 설정에서는 px : rem 이 10: 1 비율로 50px일시 5rem으로 조정하시면 됩니다.
rem은 root의 비율에 따라 결정되므로 현재 root의 width는 1080px로 설정, 디자인에 맞게 1440으로 바꿔서 사용??
