### PR TITLE
Feat/#26 반응형 웹 및 폰트 스타일

### DIFF
--- a/.idea/HUSTLE_web.iml
+++ b/.idea/HUSTLE_web.iml
@@ -8,5 +8,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="pretendard" level="application" />
   </component>
 </module>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="PROJECT" libraries="{pretendard}" />
+  </component>
+</project>

--- a/hustle_web/package-lock.json
+++ b/hustle_web/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "axios": "^1.4.0",
+        "pretendard": "^1.3.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.1",
@@ -19617,6 +19618,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.8.tgz",
+      "integrity": "sha512-LTuUQsX0tE4vQVS4pL5xZ7p0Z4/sOZxZxeENydS0NnhDE4EOu+3pPQS1hoa9EIbaNuy+lL4P9ngAuXhD/FluiQ=="
     },
     "node_modules/prettier": {
       "version": "2.8.8",

--- a/hustle_web/package.json
+++ b/hustle_web/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "axios": "^1.4.0",
+    "pretendard": "^1.3.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.1",

--- a/hustle_web/public/index.html
+++ b/hustle_web/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/hustle_web/src/constants/styles/GlobalStyle.tsx
+++ b/hustle_web/src/constants/styles/GlobalStyle.tsx
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
-export const supportScreenSize = 1440;
+export const supportScreenSize = 1280;
 
 export const GlobalStyle = createGlobalStyle`
   html {

--- a/hustle_web/src/constants/styles/GlobalStyle.tsx
+++ b/hustle_web/src/constants/styles/GlobalStyle.tsx
@@ -15,7 +15,7 @@ export const GlobalStyle = createGlobalStyle`
     background: white;
     margin: 0;
     padding: 0;
-    font-family: -apple-system, sans-serif, Roboto;
+    font-family: "Pretendard", -apple-system, sans-serif, Roboto;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/hustle_web/src/constants/styles/GlobalStyle.tsx
+++ b/hustle_web/src/constants/styles/GlobalStyle.tsx
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
-export const supportScreenSize = 1080;
+export const supportScreenSize = 1440;
 
 export const GlobalStyle = createGlobalStyle`
   html {

--- a/hustle_web/src/layout/DefaultLayout.tsx
+++ b/hustle_web/src/layout/DefaultLayout.tsx
@@ -21,7 +21,6 @@ const Root = styled.div`
   flex-direction: column;
   width: 1280px;
   height: 100vh;
-  background-color: purple;
 
   @media all and (max-width: ${supportScreenSize}px) {
     width: 100vw;

--- a/hustle_web/src/layout/DefaultLayout.tsx
+++ b/hustle_web/src/layout/DefaultLayout.tsx
@@ -21,7 +21,7 @@ const Root = styled.div`
   flex-direction: column;
   width: 1280px;
   height: 100vh;
-  background-color: orange;
+  background-color: purple;
 
   @media all and (max-width: ${supportScreenSize}px) {
     width: 100vw;

--- a/hustle_web/src/layout/DefaultLayout.tsx
+++ b/hustle_web/src/layout/DefaultLayout.tsx
@@ -19,9 +19,9 @@ const DefaultLayout = () => {
 const Root = styled.div`
   display: flex;
   flex-direction: column;
-  width: 1080px;
+  width: 1280px;
   height: 100vh;
-  background-color: white;
+  background-color: orange;
 
   @media all and (max-width: ${supportScreenSize}px) {
     width: 100vw;

--- a/hustle_web/src/styles/Font.ts
+++ b/hustle_web/src/styles/Font.ts
@@ -1,0 +1,18 @@
+const FONT = {
+    SIZE: {
+        TITLE3: "2rem",
+        BODY1: "1.8rem",
+        BODY2: "1.6rem",
+        BODY3: "1.4rem",
+        CAPTION: "1.2rem",
+    },
+    WEIGHT: {
+        LIGHT: 300,
+        REGULAR: 400,
+        MEDIUM: 500,
+        SEMIBOLD: 600,
+        BOLD: 700,
+    },
+} as const;
+
+export default FONT;


### PR DESCRIPTION
## 📌 관련 이슈
Feat/#26 반응형 웹 & 폰트 스타일 설정

## ✨ PR Checklist
- [x] 미디어 쿼리 설정
- [x] 폰트 스타일 설정

## 📸 핵심 변동사항
기본 root 사이즈 1280px 고정(min-width로 변동될 수도 있음) 
디자인 파일에 있는 모든 px 단위는 10:1 비율로 rem으로 바로 수정하시면 됩니다. 
일의 자리의 숫자 단위가 홀수일 경우 저 멘션 하셔서 수정 요청 보내주시면 됩니다.
아래 사진은 폰트 스타일 기본 설정 값입니다. 여기서 호출해서 사용하시면 됩니다.
![image](https://github.com/HUSTLE-UMC/HUSTLE_web/assets/101927445/5302f286-1a8f-4ebe-bd49-85c7f319d8ca)



## 📚 리뷰어 유의사항
핵심 변동사항 참고
